### PR TITLE
Switch from STS Gradle to buildship

### DIFF
--- a/eclipse-neon-example/03_eclipse-javadev.conf
+++ b/eclipse-neon-example/03_eclipse-javadev.conf
@@ -1,6 +1,5 @@
 remote-url:http://download.eclipse.org/eclipse/updates/4.6
 remote-url:http://download.eclipse.org/releases/neon
-remote-url:http://dist.springsource.com/release/TOOLS/gradle
 remote-url:http://findbugs.cs.umd.edu/eclipse
 remote-url:http://update.eclemma.org
 remote-url:http://cucumber.github.com/cucumber-eclipse/update-site
@@ -11,7 +10,7 @@ iu:org.eclipse.m2e.feature.feature.group
 iu:org.eclipse.m2e.logback.feature.feature.group
 
 # Gradle
-iu:org.springsource.ide.eclipse.gradle.feature.feature.group
+iu:org.eclipse.buildship.feature.group
 
 # Eclemma/Jacoco
 iu:com.mountainminds.eclemma.feature.feature.group


### PR DESCRIPTION
As per https://git.io/vXi1g the STS plugin has now been deprecated and
migration to the official Gradle 'buildship' plugin is recommended.