### PR TITLE
Switch scala-ide repository to new eclipse 4.6 one

### DIFF
--- a/eclipse-neon-example/04_eclipse-scala-ide.conf
+++ b/eclipse-neon-example/04_eclipse-scala-ide.conf
@@ -1,4 +1,4 @@
-remote-url:http://download.scala-ide.org/sdk/lithium/e44/scala211/stable/site
+remote-url:http://download.scala-ide.org/sdk/lithium/e46/scala211/stable/site
 remote-url:http://eclipse-color-theme.github.io/update
 remote-url:http://alchim31.free.fr/m2e-scala/update-site
 remote-url:http://download.eclipse.org/eclipse/updates/4.6


### PR DESCRIPTION
Now that they officially build and package on neon, switch to that updatesite